### PR TITLE
fix(tag): specify GHA email

### DIFF
--- a/tag-commit/action.yaml
+++ b/tag-commit/action.yaml
@@ -33,5 +33,9 @@ runs:
       shell: bash
       run: |-
         cd ${{ inputs.work-dir }}
+
+        git config user.name "GitHub Actions"
+        git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
         git tag ${{ inputs.tag }} ${{ inputs.commit }} --message 'Tagged in: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}'
         git push origin ${{ inputs.tag }}


### PR DESCRIPTION
This email/app is owned by GitHub and not us.